### PR TITLE
Blazor fixes

### DIFF
--- a/BlazorClient/Pages/Play.razor
+++ b/BlazorClient/Pages/Play.razor
@@ -13,11 +13,3 @@
 <div id="canvasContainer" style="position: fixed; opacity: 1; background-color: black; width: 100%; height: 100%">
     <BECanvas @ref="_canvas"></BECanvas>
 </div>
-
-<img @ref="_blueSquare" hidden src="assets/bluesquare.png" />
-<img @ref="_darkBlueSquare" hidden src="assets/darkbluesquare.png" />
-<img @ref="_greenSquare" hidden src="assets/greensquare.png" />
-<img @ref="_darkGreenSquare" hidden src="assets/darkgreensquare.png" />
-<img @ref="_orangeSquare" hidden src="assets/orangesquare.png" />
-<img @ref="_darkOrangeSquare" hidden src="assets/darkorangesquare.png" />
-<img @ref="_redSquare" hidden src="assets/redsquare.png" />

--- a/BlazorClient/Pages/Play.razor.cs
+++ b/BlazorClient/Pages/Play.razor.cs
@@ -134,7 +134,7 @@ public partial class Play : IAsyncDisposable
     }
 
     [JSInvokable]
-    public async ValueTask GameLoop()
+    public async Task GameLoop()
     {
         await Render();
     }
@@ -208,7 +208,7 @@ public partial class Play : IAsyncDisposable
     }
 
     [JSInvokable]
-    public async ValueTask OnKeyDown(int keyCode)
+    public async Task OnKeyDown(int keyCode)
     {
         if (_hubConnection is null)
         {

--- a/BlazorClient/Pages/Play.razor.cs
+++ b/BlazorClient/Pages/Play.razor.cs
@@ -120,13 +120,21 @@ public partial class Play : IAsyncDisposable
             throw new InvalidOperationException($"'{nameof(_context)}' shouldn't be null.");
         }
 
-        if (clear)
+        await _context.BeginBatchAsync();
+        try
         {
-            await _context.ClearRectAsync(0, 0, _width, _height);
+            if (clear)
+            {
+                await _context.ClearRectAsync(0, 0, _width, _height);
+            }
+            await _context.SetStrokeStyleAsync("white");
+            await _context.SetFontAsync("24px ver2dana");
+            await _context.StrokeTextAsync(text, x, y);
         }
-        await _context.SetStrokeStyleAsync("white");
-        await _context.SetFontAsync("24px ver2dana");
-        await _context.StrokeTextAsync(text, x, y);
+        finally
+        {
+            await _context.EndBatchAsync();
+        }
     }
 
     [JSInvokable]
@@ -208,9 +216,9 @@ public partial class Play : IAsyncDisposable
         var head = player.Body[0];
         await _context.SetFillStyleAsync(headColor);
         await _context.FillRectAsync(head.X * width, head.Y * height, width, height);
+        await _context.SetFillStyleAsync(tailColor);
         foreach (var b in player.Body.Skip(1))
         {
-            await _context.SetFillStyleAsync(tailColor);
             await _context.FillRectAsync(b.X * width, b.Y * height, width, height);
 
         }

--- a/BlazorClient/Pages/Play.razor.cs
+++ b/BlazorClient/Pages/Play.razor.cs
@@ -4,7 +4,6 @@ using Blazor.Extensions.Canvas.Canvas2D;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.SignalR.Client;
 using Microsoft.JSInterop;
-using System.Drawing;
 
 namespace Snakes.Client.Pages;
 
@@ -13,18 +12,11 @@ public partial class Play : IAsyncDisposable
     BECanvas? _canvas;
     Canvas2DContext? _context;
     HubConnection? _hubConnection;
-    ElementReference _blueSquare;
-    ElementReference _darkBlueSquare;
-    ElementReference _greenSquare;
-    ElementReference _darkGreenSquare;
-    ElementReference _orangeSquare;
-    ElementReference _darkOrangeSquare;
-    ElementReference _redSquare;
 
     private int _expectedPlayers;
     private int _currentPlayers;
     private GameState _gameState;
-    private Size _boardSize;
+    private Size _boardSize = new();
     private bool _alive = true;
     private int _score;
     private string _id = "";
@@ -84,7 +76,11 @@ public partial class Play : IAsyncDisposable
             await OutputTextAsync("Press enter to start with NPCs", clear: false, x: 100, y: 200);
 
         });
-        _hubConnection.On<Size>("OnBoardSizeChanged", size => _boardSize = size);
+        _hubConnection.On<Size>("OnBoardSizeChanged", async size =>
+        {
+            _boardSize = size;
+            await OutputTextAsync($"Board size changed to {_boardSize}", clear: true, 100, 100);
+        });
         _hubConnection.On<IList<PlayerState>, IEnumerable<Point>>("OnNewRound", UpdatePlayerState);
 
         _hubConnection.On<string>("OnDied", id => _alive = false);
@@ -104,7 +100,7 @@ public partial class Play : IAsyncDisposable
             _currentPlayers = lobbyState.CurrentPlayers;
             _expectedPlayers = lobbyState.ExpectedPlayers;
             _boardSize = lobbyState.BoardSize;
-            await OutputTextAsync($"Found existing lobby. Waiting for more players, currently {_currentPlayers}/{_expectedPlayers}.", clear: true, 100, 100);
+            await OutputTextAsync($"Found existing lobby, game size {_boardSize}. Waiting for more players, currently {_currentPlayers}/{_expectedPlayers}.", clear: true, 100, 100);
             await OutputTextAsync("Press enter to start with NPCs", clear: false, x: 100, y: 200);
         }
         else
@@ -155,36 +151,54 @@ public partial class Play : IAsyncDisposable
 
             _lastRenderedRound = _currentRound;
 
-            await _context.ClearRectAsync(0, 0, _width, _height);
-
-            var xscale = _width / _boardSize.Width;
-            var yscale = _height / _boardSize.Height;
-            foreach (var p in _players)
+            await _context.BeginBatchAsync();
+            try
             {
-                if (p.Id == _id)
-                {
-                    await DrawPlayer(p, _blueSquare, _darkBlueSquare, xscale, yscale);
-                }
-                else if (p.HumanControlled)
-                {
-                    await DrawPlayer(p, _orangeSquare, _darkOrangeSquare, xscale, yscale);
-                }
-                else
-                {
-                    await DrawPlayer(p, _greenSquare, _darkGreenSquare, xscale, yscale);
-                }
-            }
+                await _context.ClearRectAsync(0, 0, _width, _height);
 
-            foreach (var b in _berries)
+                if (_boardSize.Width <= 0)
+                {
+                    throw new Exception($"_boardSize.Width is {_boardSize.Width}");
+                }
+                if (_boardSize.Height <= 0)
+                {
+                    throw new Exception($"_boardSize.Height is {_boardSize.Height}");
+                }
+                var xscale = _width / _boardSize.Width;
+                var yscale = _height / _boardSize.Height;
+
+                foreach (var p in _players)
+                {
+                    if (p.Id == _id)
+                    {
+                        await DrawPlayer(p, "blue", "darkblue", xscale, yscale);
+                    }
+                    else if (p.HumanControlled)
+                    {
+                        await DrawPlayer(p, "orange", "darkorange", xscale, yscale);
+                    }
+                    else
+                    {
+                        await DrawPlayer(p, "green", "darkgreen", xscale, yscale);
+                    }
+                }
+
+                foreach (var b in _berries)
+                {
+                    await _context.SetFillStyleAsync("red");
+                    await _context.FillRectAsync(b.X * xscale, b.Y * yscale, xscale, yscale);
+                }
+
+                await OutputTextAsync($"Score: {_score}", clear: false, 5, 50);
+            }
+            finally
             {
-                await _context.DrawImageAsync(this._redSquare, b.X * xscale, b.Y * yscale, xscale, yscale);
+                await _context.EndBatchAsync();
             }
-
-            await OutputTextAsync($"Score: {_score}", clear: false, 5, 50);
         }
     }
 
-    async Task DrawPlayer(PlayerState player, ElementReference headColor, ElementReference tailColor, int width, int height)
+    async Task DrawPlayer(PlayerState player, string headColor, string tailColor, int width, int height)
     {
         if (_context is null)
         {
@@ -192,10 +206,12 @@ public partial class Play : IAsyncDisposable
         }
 
         var head = player.Body[0];
-        await _context.DrawImageAsync(headColor, head.X * width, head.Y * height, width, height);
+        await _context.SetFillStyleAsync(headColor);
+        await _context.FillRectAsync(head.X * width, head.Y * height, width, height);
         foreach (var b in player.Body.Skip(1))
         {
-            await _context.DrawImageAsync(tailColor, b.X * width, b.Y * height, width, height);
+            await _context.SetFillStyleAsync(tailColor);
+            await _context.FillRectAsync(b.X * width, b.Y * height, width, height);
 
         }
     }

--- a/ConsoleSnake/Program.cs
+++ b/ConsoleSnake/Program.cs
@@ -1,8 +1,6 @@
 ﻿using Microsoft.AspNetCore.SignalR.Client;
 using Snakes;
 using Spectre.Console;
-using System.Collections.Generic;
-using System.Drawing;
 
 using Color = Spectre.Console.Color;
 
@@ -14,7 +12,7 @@ AnsiConsole.Background = Color.Black;
 var gameState = GameState.NoGame;
 var currentPlayers = 0;
 var expectedPlayers = 0;
-var boardSize = Size.Empty;
+var boardSize = new Size();
 var alive = true;
 var score = 0;
 var id = "";

--- a/GrainInterfaces/IGame.cs
+++ b/GrainInterfaces/IGame.cs
@@ -1,6 +1,5 @@
 ﻿using Orleans;
 using System.Collections.Generic;
-using System.Drawing;
 using System.Threading.Tasks;
 
 namespace Snakes;

--- a/GrainInterfaces/IGameObserver.cs
+++ b/GrainInterfaces/IGameObserver.cs
@@ -1,6 +1,5 @@
 ﻿using Orleans;
 using System.Collections.Generic;
-using System.Drawing;
 using System.Threading.Tasks;
 
 namespace Snakes;

--- a/GrainInterfaces/IPlayer.cs
+++ b/GrainInterfaces/IPlayer.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System;
 using System.Threading.Tasks;
-using System.Drawing;
 
 namespace Snakes;
 

--- a/Grains/GameGrain.cs
+++ b/Grains/GameGrain.cs
@@ -2,10 +2,7 @@
 using Orleans;
 using System;
 using System.Collections.Generic;
-using System.Drawing;
 using System.Linq;
-using System.Text;
-using System.Threading;
 using System.Threading.Tasks;
 
 namespace Snakes;
@@ -15,7 +12,7 @@ public class GameGrain : Grain, IGame
     private readonly ObserverManager<IGameObserver> _subscriptionManager;
     private readonly List<Point> _berries = new();
     private readonly List<IPlayer> _players = new();
-    private Size _boardSize;
+    private Size _boardSize = new();
     private int _expectedPlayers;
     private GameState _currentState = GameState.NoGame;
     private IDisposable? _timerHandle;

--- a/Grains/PlayerGrain.cs
+++ b/Grains/PlayerGrain.cs
@@ -2,7 +2,6 @@
 using Orleans;
 using System;
 using System.Collections.Generic;
-using System.Drawing;
 using System.Linq;
 using System.Threading.Tasks;
 
@@ -11,7 +10,7 @@ namespace Snakes;
 public class PlayerGrain : Grain, IPlayer
 {
     private readonly List<Point> _body = new(5);
-    private Size _boardSize;
+    private Size _boardSize = new();
     private Point? _last;
     private int _score;
     private bool _isAlive = true;
@@ -94,7 +93,7 @@ public class PlayerGrain : Grain, IPlayer
         _score++;
         if (_last is not null)
         {
-            _body.Add(_last.Value);
+            _body.Add(_last);
         }
         return Task.CompletedTask;
     }

--- a/HubAndHost/Pages/_Layout.cshtml
+++ b/HubAndHost/Pages/_Layout.cshtml
@@ -34,9 +34,13 @@
     <script src="_content/Blazor.Extensions.Canvas/blazor.extensions.canvas.js"></script>
 
     <script>
-        function gameLoop(timeStamp) {
+        async function gameLoop(timeStamp) {
             window.requestAnimationFrame(gameLoop);
-            game.instance.invokeMethodAsync('GameLoop');
+            await game.instance.invokeMethodAsync('GameLoop');
+        }
+
+        async function onKeyDown(e) {
+            await game.instance.invokeMethodAsync('OnKeyDown', e.keyCode);
         }
 
         function onResize() {
@@ -46,7 +50,7 @@
             game.canvas.width = window.innerWidth;
             game.canvas.height = window.innerHeight;
 
-            game.instance.invokeMethodAsync('OnResize', window.innerWidth, window.innerHeight)
+            game.instance.invokeMethod('OnResize', window.innerWidth, window.innerHeight)
         }
 
         window.initGame = (instance) => {
@@ -57,11 +61,10 @@
                 canvas: canvases.length ? canvases[0] : null
             };
 
-            window.onkeydown = (e) => {
-                game.instance.invokeMethodAsync('OnKeyDown', e.keyCode);
-            };
-
+            window.addEventListener("keydown", onKeyDown)
             window.addEventListener("resize", onResize);
+
+            // Call once to set initial state.
             onResize();
 
             window.requestAnimationFrame(gameLoop);

--- a/HubAndHost/SnakeHub.cs
+++ b/HubAndHost/SnakeHub.cs
@@ -1,6 +1,5 @@
 ﻿using Microsoft.AspNetCore.SignalR;
 using Orleans;
-using System.Drawing;
 
 namespace Snakes;
 

--- a/SharedTypes/Extensions.cs
+++ b/SharedTypes/Extensions.cs
@@ -1,5 +1,4 @@
-﻿using System.Drawing;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using System.Linq;

--- a/SharedTypes/LobbyState.cs
+++ b/SharedTypes/LobbyState.cs
@@ -1,6 +1,4 @@
-﻿using System.Drawing;
-
-namespace Snakes;
+﻿namespace Snakes;
 
 public record class LobbyState(
     int CurrentPlayers,

--- a/SharedTypes/PlayerState.cs
+++ b/SharedTypes/PlayerState.cs
@@ -1,6 +1,4 @@
-﻿using System.Drawing;
-
-namespace Snakes;
+﻿namespace Snakes;
 
 public record PlayerState(
     string Id,

--- a/SharedTypes/Size.cs
+++ b/SharedTypes/Size.cs
@@ -1,0 +1,105 @@
+﻿namespace Snakes;
+
+public class Size : IEquatable<Size?>
+{
+    public Size()
+    {
+        Width = 0;
+        Height = 0;
+    }
+
+    public Size(int width, int height)
+    {
+        Width = width;
+        Height = height;
+    }
+
+    public int Width { get; private set; }
+
+    public int Height { get; private set; }
+
+
+    public override string? ToString()
+    {
+        return $"{{{Width},{Height}}})";
+    }
+
+    public override bool Equals(object? obj)
+    {
+        return Equals(obj as Size);
+    }
+
+    public bool Equals(Size? other)
+    {
+        return other is not null &&
+               Width == other.Width &&
+               Height == other.Height;
+    }
+
+    public override int GetHashCode()
+    {
+        return HashCode.Combine(Width, Height);
+    }
+
+    public static bool operator ==(Size? left, Size? right)
+    {
+        return EqualityComparer<Size>.Default.Equals(left, right);
+    }
+
+    public static bool operator !=(Size? left, Size? right)
+    {
+        return !(left == right);
+    }
+}
+
+public class Point : IEquatable<Point?>
+{
+    public Point()
+    {
+        X = 0;
+        Y = 0;
+    }
+
+    public Point(int x, int y)
+    {
+        X = x;
+        Y = y;
+    }
+
+    public int X { get; private set; }
+
+    public int Y { get; private set; }
+
+    public override string? ToString()
+    {
+        return $"({X},{Y})";
+    }
+
+    public override bool Equals(object? obj)
+    {
+        return Equals(obj as Point);
+    }
+
+    public bool Equals(Point? other)
+    {
+        return other is not null &&
+               X == other.X &&
+               Y == other.Y;
+    }
+
+    public override int GetHashCode()
+    {
+        return HashCode.Combine(X, Y);
+    }
+
+    public static bool operator ==(Point? left, Point? right)
+    {
+        return EqualityComparer<Point>.Default.Equals(left, right);
+    }
+
+    public static bool operator !=(Point? left, Point? right)
+    {
+        return !(left == right);
+    }
+}
+

--- a/SharedTypes/Size.cs
+++ b/SharedTypes/Size.cs
@@ -14,9 +14,9 @@ public class Size : IEquatable<Size?>
         Height = height;
     }
 
-    public int Width { get; private set; }
+    public int Width { get; set; }
 
-    public int Height { get; private set; }
+    public int Height { get; set; }
 
 
     public override string? ToString()
@@ -66,9 +66,9 @@ public class Point : IEquatable<Point?>
         Y = y;
     }
 
-    public int X { get; private set; }
+    public int X { get; set; }
 
-    public int Y { get; private set; }
+    public int Y { get; set; }
 
     public override string? ToString()
     {


### PR DESCRIPTION
Fixes #8 and #11.

Seems like `System.Drawing.Point` and `System.Drawing.Size` don't serialize properly in the published WASM runtime, though they worked fine in the console app.  Something gets stripped out of them?